### PR TITLE
Add SQLite write translation helper and tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "export-data": "echo 'Use the /export endpoint: curl http://localhost:8787/export?table=tablename > export.sql'",
     "validate": "wrangler d1 list && echo 'Validation: Check that your D1 database ID matches wrangler.toml'",
     "get-schema": "echo 'Get database schema: curl http://localhost:8787/schema'",
-    "get-migration": "echo 'Generate migration script: curl http://localhost:8787/migration-script > postgres-migration.sql'"
+    "get-migration": "echo 'Generate migration script: curl http://localhost:8787/migration-script > postgres-migration.sql'",
+    "test": "node --import tsx --test test/**/*.test.ts"
   },
   "keywords": [
     "cloudflare",

--- a/src/auto-mirror.ts
+++ b/src/auto-mirror.ts
@@ -1,4 +1,5 @@
 import { Env } from './worker';
+import { translateSqliteWriteToPostgres } from './sql-utils';
 
 export class AutoMirrorDB {
     constructor(private env: Env) { }
@@ -76,11 +77,20 @@ export class AutoMirrorDB {
     private async mirrorToPostgres(sql: string, params: unknown[]) {
         try {
             const pgSql = this.convertPlaceholders(sql, params.length);
+            const translation = await translateSqliteWriteToPostgres(this.env, pgSql, params);
+
+            if (translation.type === 'skip') {
+                console.log(
+                    `Skipping Postgres mirror for statement "${truncateSql(sql)}": ${translation.reason}`
+                );
+                return;
+            }
+
             const opId = crypto.randomUUID();
 
             await this.env.MIRROR_QUEUE.send({
-                sql: pgSql,
-                params,
+                sql: translation.sql,
+                params: translation.params,
                 opId
             });
         } catch (error) {
@@ -93,4 +103,12 @@ export class AutoMirrorDB {
         let i = 1;
         return sql.replace(/\?/g, () => `$${i++}`);
     }
-} 
+}
+
+function truncateSql(sql: string, max = 80): string {
+    const normalized = sql.replace(/\s+/g, ' ').trim();
+    if (normalized.length <= max) {
+        return normalized;
+    }
+    return `${normalized.slice(0, max - 1)}…`;
+}

--- a/src/sql-utils.ts
+++ b/src/sql-utils.ts
@@ -1,0 +1,350 @@
+import type { Env } from './worker';
+import { getTableInfo } from './db-router';
+
+type TableInfoRow = { name: string; pk: number };
+
+type TableInfoLoader = typeof getTableInfo;
+
+export type TranslationResult =
+    | { type: 'translated'; sql: string; params: unknown[] }
+    | { type: 'skip'; reason: string };
+
+export interface TranslationOptions {
+    loadTableInfo?: TableInfoLoader;
+}
+
+const tableInfoCache = new Map<string, TableInfoRow[]>();
+
+const SKIP_KEYWORDS = new Set([
+    'PRAGMA',
+    'VACUUM',
+    'ATTACH',
+    'DETACH',
+    'BEGIN',
+    'COMMIT',
+    'ROLLBACK'
+]);
+
+export async function translateSqliteWriteToPostgres(
+    env: Env,
+    sql: string,
+    params: unknown[],
+    options: TranslationOptions = {}
+): Promise<TranslationResult> {
+    const loader = options.loadTableInfo ?? getTableInfo;
+    const { statement, hasTerminator } = normalizeStatement(sql);
+
+    if (!statement) {
+        return { type: 'skip', reason: 'Empty SQL statement' };
+    }
+
+    if (statement.includes(';')) {
+        return { type: 'skip', reason: 'Multiple statements are not supported' };
+    }
+
+    const collapsed = collapseWhitespace(statement);
+    if (!collapsed) {
+        return { type: 'skip', reason: 'Empty SQL statement' };
+    }
+
+    const firstToken = collapsed.split(' ')[0]?.toUpperCase();
+    if (!firstToken) {
+        return { type: 'skip', reason: 'Unable to determine statement type' };
+    }
+
+    if (SKIP_KEYWORDS.has(firstToken)) {
+        return { type: 'skip', reason: `${firstToken} statements are not mirrored` };
+    }
+
+    const insertResult = await translateInsertLike(env, statement, loader, { hasTerminator });
+    if (insertResult) {
+        if ('skip' in insertResult) {
+            return { type: 'skip', reason: insertResult.skip };
+        }
+        return { type: 'translated', sql: insertResult.sql, params };
+    }
+
+    const updateResult = await translateUpdateWithLimit(env, statement, loader, { hasTerminator });
+    if (updateResult) {
+        if ('skip' in updateResult) {
+            return { type: 'skip', reason: updateResult.skip };
+        }
+        return { type: 'translated', sql: updateResult.sql, params };
+    }
+
+    const deleteResult = await translateDeleteWithLimit(env, statement, loader, { hasTerminator });
+    if (deleteResult) {
+        if ('skip' in deleteResult) {
+            return { type: 'skip', reason: deleteResult.skip };
+        }
+        return { type: 'translated', sql: deleteResult.sql, params };
+    }
+
+    return { type: 'translated', sql: appendTerminator(statement, hasTerminator), params };
+}
+
+type TranslationResponse = { sql: string } | { skip: string } | null;
+
+async function translateInsertLike(
+    env: Env,
+    statement: string,
+    loader: TableInfoLoader,
+    context: { hasTerminator: boolean }
+): Promise<TranslationResponse> {
+    const trimmed = statement.trimStart();
+    const upper = trimmed.toUpperCase();
+
+    let statementForParsing = statement;
+    let forcedBehavior: 'REPLACE' | undefined;
+
+    if (upper.startsWith('REPLACE')) {
+        forcedBehavior = 'REPLACE';
+        statementForParsing = statement.replace(/^REPLACE\s+/i, 'INSERT OR REPLACE ');
+    }
+
+    const insertMatch = /^(INSERT)\s+(?:OR\s+(IGNORE|REPLACE))?\s+INTO\s+([^\s(]+)\s*(\(([^)]*)\))?/i.exec(statementForParsing.trimStart());
+    if (!insertMatch) {
+        return null;
+    }
+
+    const behavior = (forcedBehavior ?? insertMatch[2]?.toUpperCase()) as ('IGNORE' | 'REPLACE' | undefined);
+
+    if (!behavior) {
+        return null;
+    }
+
+    const tableRef = insertMatch[3];
+    const columnClause = insertMatch[4] ?? '';
+    const rawColumnList = insertMatch[5];
+    const rest = statementForParsing.slice(insertMatch[0].length).trimStart();
+
+    const normalizedTableName = normalizeTableName(tableRef);
+
+    const tableInfo = await fetchTableInfo(env, normalizedTableName, loader);
+    if (!tableInfo || tableInfo.length === 0) {
+        return { skip: `Missing table metadata for ${normalizedTableName}` };
+    }
+
+    const primaryKeys = tableInfo
+        .filter(col => Number(col.pk) > 0)
+        .sort((a, b) => Number(a.pk) - Number(b.pk))
+        .map(col => col.name);
+
+    if (primaryKeys.length === 0) {
+        return { skip: `Table ${normalizedTableName} has no primary key to use as conflict target` };
+    }
+
+    const conflictTarget = primaryKeys.map(col => quoteIdentifier(col)).join(', ');
+    const insertHead = `INSERT INTO ${tableRef}${columnClause ? ` ${columnClause}` : ''}`;
+    const baseInsert = `${insertHead}${rest ? ` ${rest}` : ''}`.trim();
+
+    if (behavior === 'IGNORE') {
+        const rewritten = `${baseInsert} ON CONFLICT (${conflictTarget}) DO NOTHING`;
+        return { sql: appendTerminator(rewritten, context.hasTerminator) };
+    }
+
+    const parsedColumns = parseColumnList(rawColumnList, tableInfo);
+    const updateColumns = parsedColumns.filter(col => !primaryKeys.includes(col));
+    const columnsToUpdate = updateColumns.length > 0 ? updateColumns : parsedColumns;
+
+    if (columnsToUpdate.length === 0) {
+        return { skip: `Unable to determine columns for REPLACE on ${normalizedTableName}` };
+    }
+
+    const assignments = columnsToUpdate
+        .map(col => `${quoteIdentifier(col)} = EXCLUDED.${quoteIdentifier(col)}`)
+        .join(', ');
+
+    const rewritten = `${baseInsert} ON CONFLICT (${conflictTarget}) DO UPDATE SET ${assignments}`;
+    return { sql: appendTerminator(rewritten, context.hasTerminator) };
+}
+
+async function translateUpdateWithLimit(
+    env: Env,
+    statement: string,
+    loader: TableInfoLoader,
+    context: { hasTerminator: boolean }
+): Promise<TranslationResponse> {
+    const limitMatch = /\sLIMIT\s+([^\s]+)\s*$/i.exec(statement);
+    if (!limitMatch) {
+        return null;
+    }
+
+    if (!/^UPDATE\s+/i.test(statement)) {
+        return null;
+    }
+
+    if (/\bRETURNING\b/i.test(statement)) {
+        return { skip: 'UPDATE ... LIMIT with RETURNING is not supported' };
+    }
+
+    const limitExpr = limitMatch[1];
+    const beforeLimit = statement.slice(0, limitMatch.index).trim();
+
+    const upper = beforeLimit.toUpperCase();
+    const setIndex = upper.indexOf(' SET ');
+    if (setIndex === -1) {
+        return { skip: 'Unable to locate SET clause for UPDATE ... LIMIT' };
+    }
+
+    const tableSegment = beforeLimit.slice('UPDATE '.length, setIndex).trim();
+    if (!tableSegment || /\s/.test(tableSegment)) {
+        return { skip: 'UPDATE ... LIMIT with table aliases is not supported' };
+    }
+
+    const setAndWhere = beforeLimit.slice(setIndex + 5).trim();
+    if (!setAndWhere) {
+        return { skip: 'Empty SET clause for UPDATE ... LIMIT' };
+    }
+
+    const whereIndex = setAndWhere.toUpperCase().indexOf(' WHERE ');
+    const setClause = whereIndex === -1 ? setAndWhere : setAndWhere.slice(0, whereIndex).trim();
+    const whereClause = whereIndex === -1 ? '' : setAndWhere.slice(whereIndex + 7).trim();
+
+    const normalizedTableName = normalizeTableName(tableSegment);
+    const tableInfo = await fetchTableInfo(env, normalizedTableName, loader);
+    if (!tableInfo || tableInfo.length === 0) {
+        return { skip: `Missing table metadata for ${normalizedTableName}` };
+    }
+
+    const primaryKeys = tableInfo
+        .filter(col => Number(col.pk) > 0)
+        .sort((a, b) => Number(a.pk) - Number(b.pk))
+        .map(col => col.name);
+
+    if (primaryKeys.length === 0) {
+        return { skip: `Table ${normalizedTableName} has no primary key to use as conflict target` };
+    }
+
+    const selectColumns = primaryKeys.map(col => quoteIdentifier(col)).join(', ');
+    const limitedSelect = `SELECT ${selectColumns} FROM ${tableSegment}${whereClause ? ` WHERE ${whereClause}` : ''} LIMIT ${limitExpr}`;
+
+    const joinConditions = primaryKeys
+        .map(col => `${tableSegment}.${quoteIdentifier(col)} = limited.${quoteIdentifier(col)}`)
+        .join(' AND ');
+
+    const rewritten = `WITH limited AS (${limitedSelect}) UPDATE ${tableSegment} SET ${setClause} FROM limited WHERE ${joinConditions}`;
+    return { sql: appendTerminator(rewritten, context.hasTerminator) };
+}
+
+async function translateDeleteWithLimit(
+    env: Env,
+    statement: string,
+    loader: TableInfoLoader,
+    context: { hasTerminator: boolean }
+): Promise<TranslationResponse> {
+    const limitMatch = /\sLIMIT\s+([^\s]+)\s*$/i.exec(statement);
+    if (!limitMatch) {
+        return null;
+    }
+
+    if (!/^DELETE\s+FROM\s+/i.test(statement)) {
+        return null;
+    }
+
+    if (/\bRETURNING\b/i.test(statement)) {
+        return { skip: 'DELETE ... LIMIT with RETURNING is not supported' };
+    }
+
+    const limitExpr = limitMatch[1];
+    const beforeLimit = statement.slice(0, limitMatch.index).trim();
+
+    const deleteMatch = /^DELETE\s+FROM\s+([^\s]+)\s*(?:WHERE\s+([\s\S]*))?$/i.exec(beforeLimit);
+    if (!deleteMatch) {
+        return { skip: 'Unable to parse DELETE ... LIMIT statement' };
+    }
+
+    const tableSegment = deleteMatch[1].trim();
+    if (!tableSegment || /\s/.test(tableSegment)) {
+        return { skip: 'DELETE ... LIMIT with table aliases is not supported' };
+    }
+
+    const whereClause = deleteMatch[2]?.trim() ?? '';
+    if (/\bORDER\s+BY\b/i.test(whereClause)) {
+        return { skip: 'DELETE ... LIMIT with ORDER BY is not supported' };
+    }
+
+    const normalizedTableName = normalizeTableName(tableSegment);
+    const tableInfo = await fetchTableInfo(env, normalizedTableName, loader);
+    if (!tableInfo || tableInfo.length === 0) {
+        return { skip: `Missing table metadata for ${normalizedTableName}` };
+    }
+
+    const primaryKeys = tableInfo
+        .filter(col => Number(col.pk) > 0)
+        .sort((a, b) => Number(a.pk) - Number(b.pk))
+        .map(col => col.name);
+
+    if (primaryKeys.length === 0) {
+        return { skip: `Table ${normalizedTableName} has no primary key to use as conflict target` };
+    }
+
+    const selectColumns = primaryKeys.map(col => quoteIdentifier(col)).join(', ');
+    const limitedSelect = `SELECT ${selectColumns} FROM ${tableSegment}${whereClause ? ` WHERE ${whereClause}` : ''} LIMIT ${limitExpr}`;
+
+    const joinConditions = primaryKeys
+        .map(col => `${tableSegment}.${quoteIdentifier(col)} = limited.${quoteIdentifier(col)}`)
+        .join(' AND ');
+
+    const rewritten = `WITH limited AS (${limitedSelect}) DELETE FROM ${tableSegment} USING limited WHERE ${joinConditions}`;
+    return { sql: appendTerminator(rewritten, context.hasTerminator) };
+}
+
+async function fetchTableInfo(env: Env, tableName: string, loader: TableInfoLoader): Promise<TableInfoRow[]> {
+    const key = tableName.toLowerCase();
+    if (!tableInfoCache.has(key)) {
+        try {
+            const info = await loader(env, tableName);
+            tableInfoCache.set(key, info.map(col => ({ name: col.name, pk: Number(col.pk) })));
+        } catch (error) {
+            return [];
+        }
+    }
+
+    return tableInfoCache.get(key) ?? [];
+}
+
+function parseColumnList(rawColumnList: string | undefined, tableInfo: TableInfoRow[]): string[] {
+    if (rawColumnList && rawColumnList.trim().length > 0) {
+        return rawColumnList
+            .split(',')
+            .map(col => normalizeIdentifier(col))
+            .filter(col => col.length > 0);
+    }
+
+    return tableInfo.map(col => col.name);
+}
+
+function normalizeStatement(sql: string): { statement: string; hasTerminator: boolean } {
+    const trimmed = sql.trim();
+    const hasTerminator = /;\s*$/.test(trimmed);
+    const statement = hasTerminator ? trimmed.replace(/;\s*$/, '') : trimmed;
+    return { statement, hasTerminator };
+}
+
+function appendTerminator(statement: string, hadTerminator: boolean): string {
+    const trimmed = statement.trim();
+    return hadTerminator ? `${trimmed};` : trimmed;
+}
+
+function collapseWhitespace(value: string): string {
+    return value.replace(/\s+/g, ' ').trim();
+}
+
+function normalizeTableName(tableRef: string): string {
+    const withoutSchema = tableRef.split('.').pop() ?? tableRef;
+    return normalizeIdentifier(withoutSchema);
+}
+
+function normalizeIdentifier(identifier: string): string {
+    let value = identifier.trim();
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith('`') && value.endsWith('`')) || (value.startsWith('[') && value.endsWith(']'))) {
+        value = value.slice(1, -1);
+    }
+    return value.replace(/""/g, '"');
+}
+
+function quoteIdentifier(identifier: string): string {
+    const name = normalizeIdentifier(identifier);
+    return `"${name.replace(/"/g, '""')}"`;
+}

--- a/test/sql-utils.test.ts
+++ b/test/sql-utils.test.ts
@@ -1,0 +1,105 @@
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+
+import { AutoMirrorDB } from '../src/auto-mirror';
+import type { Env } from '../src/worker';
+
+type TableMetadata = Record<string, Array<{ name: string; pk: number }>>;
+
+test('INSERT OR IGNORE statements are rewritten for Postgres mirroring', async () => {
+    const { env, messages } = createTestEnv({
+        users: [
+            { name: 'id', pk: 1 },
+            { name: 'name', pk: 0 }
+        ]
+    });
+
+    const db = new AutoMirrorDB(env);
+    await (db as any).mirrorToPostgres('INSERT OR IGNORE INTO users (id, name) VALUES (?, ?)', [1, 'Ada']);
+
+    assert.equal(messages.length, 1, 'statement should be enqueued');
+    assert.equal(
+        messages[0].sql,
+        'INSERT INTO users (id, name) VALUES ($1, $2) ON CONFLICT ("id") DO NOTHING'
+    );
+    assert.deepEqual(messages[0].params, [1, 'Ada']);
+});
+
+test('REPLACE INTO is converted to an upsert for Postgres', async () => {
+    const { env, messages } = createTestEnv({
+        users: [
+            { name: 'id', pk: 1 },
+            { name: 'name', pk: 0 },
+            { name: 'email', pk: 0 }
+        ]
+    });
+
+    const db = new AutoMirrorDB(env);
+    await (db as any).mirrorToPostgres('REPLACE INTO users (id, name, email) VALUES (?, ?, ?)', [1, 'Ada', 'ada@example.com']);
+
+    assert.equal(messages.length, 1, 'statement should be enqueued');
+    assert.equal(
+        messages[0].sql,
+        'INSERT INTO users (id, name, email) VALUES ($1, $2, $3) ON CONFLICT ("id") DO UPDATE SET "name" = EXCLUDED."name", "email" = EXCLUDED."email"'
+    );
+    assert.deepEqual(messages[0].params, [1, 'Ada', 'ada@example.com']);
+});
+
+test('DELETE ... LIMIT is rewritten using a limiting CTE', async () => {
+    const { env, messages } = createTestEnv({
+        users: [
+            { name: 'id', pk: 1 },
+            { name: 'name', pk: 0 }
+        ]
+    });
+
+    const db = new AutoMirrorDB(env);
+    await (db as any).mirrorToPostgres('DELETE FROM users WHERE name = ? LIMIT 1', ['Ada']);
+
+    assert.equal(messages.length, 1, 'statement should be enqueued');
+    assert.equal(
+        messages[0].sql,
+        'WITH limited AS (SELECT "id" FROM users WHERE name = $1 LIMIT 1) DELETE FROM users USING limited WHERE users."id" = limited."id"'
+    );
+    assert.deepEqual(messages[0].params, ['Ada']);
+});
+
+test('PRAGMA statements are skipped to avoid poisoning the queue', async () => {
+    const { env, messages } = createTestEnv({ users: [{ name: 'id', pk: 1 }] });
+
+    const db = new AutoMirrorDB(env);
+    await (db as any).mirrorToPostgres('PRAGMA table_info(users)', []);
+
+    assert.equal(messages.length, 0, 'PRAGMA should not be enqueued');
+});
+
+function createTestEnv(metadata: TableMetadata): { env: Env; messages: any[] } {
+    const messages: any[] = [];
+    const env: Env = {
+        PRIMARY_DB: 'd1',
+        PG: undefined,
+        PG_DSN: undefined,
+        DB: {
+            prepare(sql: string) {
+                const match = /PRAGMA\s+table_info\((.+)\)/i.exec(sql);
+                if (!match) {
+                    throw new Error(`Unexpected SQL in test stub: ${sql}`);
+                }
+
+                const tableName = match[1].replace(/["`\[\]]/g, '');
+                const normalized = tableName.split('.').pop() ?? tableName;
+
+                return {
+                    all: async () => ({ results: metadata[normalized] ?? [] })
+                } as any;
+            }
+        } as any,
+        MIRROR_QUEUE: {
+            async send(payload: any) {
+                messages.push(payload);
+            }
+        } as any
+    };
+
+    return { env, messages };
+}


### PR DESCRIPTION
## Summary
- add a translator that normalizes SQLite write statements and rewrites common SQLite-only patterns for Postgres
- invoke the translator during mirroring so unsupported statements are skipped instead of retried endlessly
- cover INSERT OR IGNORE, REPLACE, and DELETE ... LIMIT mirroring along with PRAGMA skips in unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68cc931e873c8324bb9b430a6ead69ad