### PR TITLE
Handle named placeholder conversion for Postgres mirror

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "export-data": "echo 'Use the /export endpoint: curl http://localhost:8787/export?table=tablename > export.sql'",
     "validate": "wrangler d1 list && echo 'Validation: Check that your D1 database ID matches wrangler.toml'",
     "get-schema": "echo 'Get database schema: curl http://localhost:8787/schema'",
-    "get-migration": "echo 'Generate migration script: curl http://localhost:8787/migration-script > postgres-migration.sql'"
+    "get-migration": "echo 'Generate migration script: curl http://localhost:8787/migration-script > postgres-migration.sql'",
+    "test": "tsx tests/auto-mirror.test.ts"
   },
   "keywords": [
     "cloudflare",

--- a/src/auto-mirror.ts
+++ b/src/auto-mirror.ts
@@ -1,4 +1,5 @@
 import { Env } from './worker';
+import { convertSqlitePlaceholdersToPostgres, PlaceholderMappingEntry, normalizeNamedBindings, buildPostgresParameterArray } from './sql-utils';
 
 export class AutoMirrorDB {
     constructor(private env: Env) { }
@@ -8,48 +9,69 @@ export class AutoMirrorDB {
 
         this.env.DB.prepare = (sql: string) => {
             const stmt = originalPrepare(sql);
+            return this.patchStatement(stmt, sql);
+        };
+    }
+
+    private patchStatement<T extends D1PreparedStatement>(stmt: T, sql: string): T {
+        const { sql: pgSql, mapping } = convertSqlitePlaceholdersToPostgres(sql);
+        const isWriteOperation = this.isWriteSQL(sql);
+
+        const applyExecutionPatches = (statement: any, boundParamsProvider: () => unknown[]) => {
+            const baseRun = captureOriginalMethod(statement, 'run');
+            if (baseRun) {
+                statement.run = async <T = Record<string, unknown>>(...args: unknown[]): Promise<D1Result<T>> => {
+                    const result = await baseRun.apply(statement, args) as D1Result<T>;
+                    if (isWriteOperation) {
+                        const params = args.length > 0
+                            ? this.normalizeParams(args, mapping)
+                            : boundParamsProvider();
+                        await this.mirrorToPostgres(pgSql, [...params]);
+                    }
+                    return result;
+                };
+            }
+
+            const baseAll = captureOriginalMethod(statement, 'all');
+            if (baseAll) {
+                statement.all = async <T = Record<string, unknown>>(...args: unknown[]): Promise<D1Result<T>> => {
+                    const result = await baseAll.apply(statement, args) as D1Result<T>;
+                    if (isWriteOperation) {
+                        const params = boundParamsProvider();
+                        await this.mirrorToPostgres(pgSql, [...params]);
+                    }
+                    return result;
+                };
+            }
+
+            const baseFirst = captureOriginalMethod(statement, 'first');
+            if (baseFirst) {
+                statement.first = async <T = Record<string, unknown>>(...args: unknown[]): Promise<T | null> => {
+                    const result = await baseFirst.apply(statement, args) as T | null;
+                    if (isWriteOperation) {
+                        const params = boundParamsProvider();
+                        await this.mirrorToPostgres(pgSql, [...params]);
+                    }
+                    return result;
+                };
+            }
+
+            return statement;
+        };
+
+        applyExecutionPatches(stmt, () => []);
+
+        if (typeof stmt.bind === 'function') {
             const originalBind = stmt.bind.bind(stmt);
-
-            stmt.bind = (...params: unknown[]) => {
-                const bound = originalBind(...params);
-
-                // Patch all methods that can execute write operations
-                const originalRun = bound.run.bind(bound);
-                const originalAll = bound.all.bind(bound);
-                const originalFirst = bound.first.bind(bound);
-
-                // Only mirror if this is a write operation (INSERT, UPDATE, DELETE)
-                const isWriteOperation = this.isWriteSQL(sql);
-
-                bound.run = async <T = Record<string, unknown>>(): Promise<D1Result<T>> => {
-                    const result = await originalRun<T>();
-                    if (isWriteOperation) {
-                        await this.mirrorToPostgres(sql, params);
-                    }
-                    return result;
-                };
-
-                bound.all = async <T = Record<string, unknown>>(): Promise<D1Result<T>> => {
-                    const result = await originalAll<T>();
-                    if (isWriteOperation) {
-                        await this.mirrorToPostgres(sql, params);
-                    }
-                    return result;
-                };
-
-                bound.first = async <T = Record<string, unknown>>(colName?: string): Promise<T | null> => {
-                    const result = await (colName ? originalFirst<T>(colName) : originalFirst<T>());
-                    if (isWriteOperation) {
-                        await this.mirrorToPostgres(sql, params);
-                    }
-                    return result;
-                };
-
+            stmt.bind = (...bindArgs: unknown[]) => {
+                const normalized = this.normalizeParams(bindArgs, mapping);
+                const bound = originalBind(...bindArgs);
+                applyExecutionPatches(bound, () => normalized);
                 return bound;
             };
+        }
 
-            return stmt;
-        };
+        return stmt;
     }
 
     private isWriteSQL(sql: string): boolean {
@@ -75,11 +97,10 @@ export class AutoMirrorDB {
 
     private async mirrorToPostgres(sql: string, params: unknown[]) {
         try {
-            const pgSql = this.convertPlaceholders(sql, params.length);
             const opId = crypto.randomUUID();
 
             await this.env.MIRROR_QUEUE.send({
-                sql: pgSql,
+                sql,
                 params,
                 opId
             });
@@ -89,8 +110,82 @@ export class AutoMirrorDB {
         }
     }
 
-    private convertPlaceholders(sql: string, count: number): string {
-        let i = 1;
-        return sql.replace(/\?/g, () => `$${i++}`);
+    private normalizeParams(rawParams: unknown[], mapping: PlaceholderMappingEntry[]): unknown[] {
+        if (mapping.length === 0) {
+            return [];
+        }
+
+        const positional: unknown[] = [];
+        const named = new Map<string, unknown>();
+
+        const addNamed = (key: string, value: unknown) => {
+            normalizeNamedBindings(named, key, value);
+        };
+
+        for (const param of rawParams) {
+            if (Array.isArray(param)) {
+                positional.push(...param);
+                continue;
+            }
+
+            if (param instanceof Map) {
+                for (const [key, value] of param.entries()) {
+                    if (typeof key === 'string') {
+                        addNamed(key, value);
+                    }
+                }
+                continue;
+            }
+
+            if (isPlainObject(param)) {
+                for (const [key, value] of Object.entries(param)) {
+                    addNamed(key, value);
+                }
+                continue;
+            }
+
+            positional.push(param);
+        }
+
+        return buildPostgresParameterArray(mapping, positional, named);
     }
-} 
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+    if (value === null || typeof value !== 'object') {
+        return false;
+    }
+
+    const prototype = Object.getPrototypeOf(value);
+    return prototype === Object.prototype || prototype === null;
+}
+
+type StatementMethod = (...args: unknown[]) => Promise<unknown>;
+
+type OriginalMethodRegistry = {
+    run?: StatementMethod;
+    all?: StatementMethod;
+    first?: StatementMethod;
+};
+
+const originalMethodRegistry = new WeakMap<object, OriginalMethodRegistry>();
+
+function captureOriginalMethod(statement: any, method: 'run' | 'all' | 'first'): StatementMethod | undefined {
+    let registry = originalMethodRegistry.get(statement);
+    if (!registry) {
+        registry = {};
+        originalMethodRegistry.set(statement, registry);
+    }
+
+    if (registry[method]) {
+        return registry[method];
+    }
+
+    const current = statement[method];
+    if (typeof current === 'function') {
+        registry[method] = current as StatementMethod;
+        return registry[method];
+    }
+
+    return undefined;
+}

--- a/src/db-router.ts
+++ b/src/db-router.ts
@@ -1,4 +1,5 @@
 import { Env } from './worker';
+import { buildPostgresParameterArray, convertSqlitePlaceholdersToPostgres } from './sql-utils';
 
 export async function executeQuery(env: Env, sql: string, params: unknown[] = []) {
     if (env.PRIMARY_DB === "pg") {
@@ -16,8 +17,11 @@ export async function executeQuery(env: Env, sql: string, params: unknown[] = []
             await client.connect();
 
             // Convert D1 placeholders to Postgres placeholders
-            const pgSql = convertPlaceholders(sql, params.length);
-            const result = await client.query(pgSql, params);
+            const { sql: pgSql, mapping } = convertSqlitePlaceholdersToPostgres(sql);
+            const normalizedParams = mapping.length > 0
+                ? buildPostgresParameterArray(mapping, params)
+                : params;
+            const result = await client.query(pgSql, normalizedParams);
 
             // Return in D1-compatible format
             return {
@@ -181,8 +185,3 @@ export async function getAllTables(env: Env): Promise<string[]> {
         }
     }
 }
-
-function convertPlaceholders(sql: string, count: number): string {
-    let i = 1;
-    return sql.replace(/\?/g, () => `$${i++}`);
-} 

--- a/src/sql-utils.ts
+++ b/src/sql-utils.ts
@@ -1,0 +1,206 @@
+export type PlaceholderMappingEntry =
+    | { kind: 'positional'; index: number }
+    | { kind: 'numbered'; index: number }
+    | { kind: 'named'; name: string; token: string };
+
+export interface ConvertedSql {
+    sql: string;
+    mapping: PlaceholderMappingEntry[];
+}
+
+const identifierStart = /[A-Za-z_]/;
+const identifierPart = /[A-Za-z0-9_]/;
+const digit = /[0-9]/;
+
+function isIdentifierStart(char: string | undefined): char is string {
+    return !!char && identifierStart.test(char);
+}
+
+function isIdentifierPart(char: string | undefined): char is string {
+    return !!char && identifierPart.test(char);
+}
+
+function isDigit(char: string | undefined): char is string {
+    return !!char && digit.test(char);
+}
+
+function isPlaceholderPrefix(char: string): boolean {
+    return char === ':' || char === '@' || char === '$';
+}
+
+export function convertSqlitePlaceholdersToPostgres(sql: string): ConvertedSql {
+    const mapping: PlaceholderMappingEntry[] = [];
+    const placeholderIndexByKey = new Map<string, number>();
+    let positionalCounter = 0;
+    let result = '';
+    const length = sql.length;
+
+    const getIndex = (key: string, entryFactory: () => PlaceholderMappingEntry): number => {
+        const existing = placeholderIndexByKey.get(key);
+        if (existing !== undefined) {
+            return existing;
+        }
+        const index = mapping.length + 1;
+        placeholderIndexByKey.set(key, index);
+        mapping.push(entryFactory());
+        return index;
+    };
+
+    let i = 0;
+    while (i < length) {
+        const char = sql[i];
+
+        if (char === '-' && i + 1 < length && sql[i + 1] === '-') {
+            result += '--';
+            i += 2;
+            while (i < length) {
+                const current = sql[i];
+                result += current;
+                if (current === '\n') {
+                    i++;
+                    break;
+                }
+                i++;
+            }
+            continue;
+        }
+
+        if (char === '/' && i + 1 < length && sql[i + 1] === '*') {
+            result += '/*';
+            i += 2;
+            while (i < length) {
+                const current = sql[i];
+                if (current === '*' && i + 1 < length && sql[i + 1] === '/') {
+                    result += '*/';
+                    i += 2;
+                    break;
+                }
+                result += current;
+                i++;
+            }
+            continue;
+        }
+
+        if (char === '\'' || char === '"' || char === '`') {
+            result += char;
+            i++;
+            while (i < length) {
+                const current = sql[i];
+                result += current;
+                if (current === char) {
+                    if ((char === '\'' || char === '"') && i + 1 < length && sql[i + 1] === char) {
+                        result += sql[i + 1];
+                        i += 2;
+                        continue;
+                    }
+                    i++;
+                    break;
+                }
+                i++;
+            }
+            continue;
+        }
+
+        if (char === '[') {
+            result += char;
+            i++;
+            while (i < length) {
+                const current = sql[i];
+                result += current;
+                if (current === ']') {
+                    i++;
+                    break;
+                }
+                i++;
+            }
+            continue;
+        }
+
+        if (char === '?') {
+            let j = i + 1;
+            while (j < length && isDigit(sql[j])) {
+                j++;
+            }
+            const digits = sql.slice(i + 1, j);
+            if (digits.length > 0) {
+                const numericIndex = Math.max(parseInt(digits, 10) - 1, 0);
+                const placeholderIndex = getIndex(`numbered-${numericIndex}`, () => ({
+                    kind: 'numbered',
+                    index: numericIndex,
+                }));
+                result += `$${placeholderIndex}`;
+            } else {
+                const positionalIndex = positionalCounter++;
+                const placeholderIndex = getIndex(`positional-${positionalIndex}`, () => ({
+                    kind: 'positional',
+                    index: positionalIndex,
+                }));
+                result += `$${placeholderIndex}`;
+            }
+            i = j;
+            continue;
+        }
+
+        if ((char === ':' || char === '@' || char === '$') && isIdentifierStart(sql[i + 1])) {
+            let j = i + 2;
+            while (j < length && isIdentifierPart(sql[j])) {
+                j++;
+            }
+            const name = sql.slice(i + 1, j);
+            const token = sql.slice(i, j);
+            const placeholderIndex = getIndex(`named-${name}`, () => ({
+                kind: 'named',
+                name,
+                token,
+            }));
+            result += `$${placeholderIndex}`;
+            i = j;
+            continue;
+        }
+
+        result += char;
+        i++;
+    }
+
+    return { sql: result, mapping };
+}
+
+export function normalizeNamedBindings(source: Map<string, unknown>, key: string, value: unknown) {
+    source.set(key, value);
+    if (!key) {
+        return;
+    }
+    if (isPlaceholderPrefix(key[0])) {
+        const bare = key.slice(1);
+        if (bare) {
+            source.set(bare, value);
+        }
+    } else {
+        source.set(`:${key}`, value);
+        source.set(`@${key}`, value);
+        source.set(`$${key}`, value);
+    }
+}
+
+export function buildPostgresParameterArray(
+    mapping: PlaceholderMappingEntry[],
+    positional: unknown[],
+    named: Map<string, unknown> = new Map(),
+): unknown[] {
+    if (mapping.length === 0) {
+        return [];
+    }
+
+    return mapping.map(entry => {
+        switch (entry.kind) {
+            case 'positional':
+            case 'numbered':
+                return positional[entry.index];
+            case 'named':
+                if (named.has(entry.token)) {
+                    return named.get(entry.token);
+                }
+                return named.get(entry.name);
+        }
+    });
+}

--- a/tests/auto-mirror.test.ts
+++ b/tests/auto-mirror.test.ts
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict';
+import { AutoMirrorDB } from '../src/auto-mirror';
+import { Env } from '../src/worker';
+
+interface MirrorMessage {
+    sql: string;
+    params: unknown[];
+    opId: string;
+}
+
+class FakeQueue {
+    public readonly messages: MirrorMessage[] = [];
+
+    async send(message: MirrorMessage): Promise<void> {
+        this.messages.push(message);
+    }
+}
+
+class FakeStatement {
+    constructor(public readonly sql: string) { }
+
+    bind(..._params: unknown[]): this {
+        return this;
+    }
+
+    async run<T = Record<string, unknown>>(..._args: unknown[]): Promise<D1Result<T>> {
+        return { success: true, results: [], meta: { changes: 1, last_row_id: 0, rows_read: 0, rows_written: 0 } } as D1Result<T>;
+    }
+
+    async all<T = Record<string, unknown>>(..._args: unknown[]): Promise<D1Result<T>> {
+        return { success: true, results: [], meta: { changes: 0, last_row_id: 0, rows_read: 0, rows_written: 0 } } as D1Result<T>;
+    }
+
+    async first<T = Record<string, unknown>>(..._args: unknown[]): Promise<T | null> {
+        return null;
+    }
+}
+
+class FakeDB {
+    prepare(sql: string): FakeStatement {
+        return new FakeStatement(sql);
+    }
+}
+
+function createTestEnv() {
+    const queue = new FakeQueue();
+    const db = new FakeDB();
+    const env = {
+        DB: db as unknown as D1Database,
+        MIRROR_QUEUE: queue as unknown as Queue,
+        PRIMARY_DB: 'd1',
+    } as unknown as Env;
+    return { env, queue };
+}
+
+async function testPositionalBinding() {
+    const { env, queue } = createTestEnv();
+    const autoMirror = new AutoMirrorDB(env);
+    await autoMirror.patchDB();
+
+    const stmt = env.DB.prepare('INSERT INTO users(name, age) VALUES (?, ?)');
+    await stmt.bind('Alice', 42).run();
+
+    assert.equal(queue.messages.length, 1, 'should enqueue a mirror message');
+    const message = queue.messages[0];
+    assert.equal(message.sql, 'INSERT INTO users(name, age) VALUES ($1, $2)');
+    assert.deepEqual(message.params, ['Alice', 42]);
+}
+
+async function testNumberedBinding() {
+    const { env, queue } = createTestEnv();
+    const autoMirror = new AutoMirrorDB(env);
+    await autoMirror.patchDB();
+
+    const stmt = env.DB.prepare('INSERT INTO events(start_at, end_at) VALUES (?2, ?1)');
+    await stmt.bind('2024-01-01', '2024-12-31').run();
+
+    const [message] = queue.messages;
+    assert.equal(message.sql, 'INSERT INTO events(start_at, end_at) VALUES ($1, $2)');
+    assert.deepEqual(message.params, ['2024-12-31', '2024-01-01']);
+}
+
+async function testNamedBindingWithObject() {
+    const { env, queue } = createTestEnv();
+    const autoMirror = new AutoMirrorDB(env);
+    await autoMirror.patchDB();
+
+    const stmt = env.DB.prepare('INSERT INTO profiles(name, age, name_again) VALUES (:name, @age, $name)');
+    await stmt.bind({ name: 'Bob', age: 30 }).run();
+
+    const [message] = queue.messages;
+    assert.equal(message.sql, 'INSERT INTO profiles(name, age, name_again) VALUES ($1, $2, $1)');
+    assert.deepEqual(message.params, ['Bob', 30]);
+}
+
+async function testNamedBindingWithMap() {
+    const { env, queue } = createTestEnv();
+    const autoMirror = new AutoMirrorDB(env);
+    await autoMirror.patchDB();
+
+    const stmt = env.DB.prepare('UPDATE profiles SET name = :name WHERE id = @id OR id = $id');
+    await stmt.bind(new Map([[':name', 'Carol'], ['id', 5]])).run();
+
+    const [message] = queue.messages;
+    assert.equal(message.sql, 'UPDATE profiles SET name = $1 WHERE id = $2 OR id = $2');
+    assert.deepEqual(message.params, ['Carol', 5]);
+}
+
+async function run() {
+    await testPositionalBinding();
+    await testNumberedBinding();
+    await testNamedBindingWithObject();
+    await testNamedBindingWithMap();
+    console.log('All tests passed');
+}
+
+run().catch(error => {
+    console.error(error);
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add `sql-utils` helpers to deterministically remap SQLite placeholders and build Postgres parameter arrays
- update the auto-mirror binding logic to flatten positional, numbered, and named bindings using the shared mapping
- switch the pg router to the shared conversion helper and add tests covering positional, numbered, and named binds

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc931f07f08324a7f26d9f5f4e6844