### PR TITLE
Improve generic D1 mirroring support

### DIFF
--- a/src/auto-mirror.ts
+++ b/src/auto-mirror.ts
@@ -1,4 +1,5 @@
 import { Env } from './worker';
+import { convertSqlitePlaceholdersToPostgres, normalizeParams } from './sql-utils';
 
 export class AutoMirrorDB {
     constructor(private env: Env) { }
@@ -7,66 +8,70 @@ export class AutoMirrorDB {
         const originalPrepare = this.env.DB.prepare.bind(this.env.DB);
 
         this.env.DB.prepare = (sql: string) => {
-            const stmt = originalPrepare(sql);
-            const originalBind = stmt.bind.bind(stmt);
+            const statement = originalPrepare(sql);
+            const originalBind = statement.bind.bind(statement);
+            const patchedStatement = this.patchStatement(statement, sql, []);
 
-            stmt.bind = (...params: unknown[]) => {
-                const bound = originalBind(...params);
-
-                // Patch all methods that can execute write operations
-                const originalRun = bound.run.bind(bound);
-                const originalAll = bound.all.bind(bound);
-                const originalFirst = bound.first.bind(bound);
-
-                // Only mirror if this is a write operation (INSERT, UPDATE, DELETE)
-                const isWriteOperation = this.isWriteSQL(sql);
-
-                bound.run = async <T = Record<string, unknown>>(): Promise<D1Result<T>> => {
-                    const result = await originalRun<T>();
-                    if (isWriteOperation) {
-                        await this.mirrorToPostgres(sql, params);
-                    }
-                    return result;
-                };
-
-                bound.all = async <T = Record<string, unknown>>(): Promise<D1Result<T>> => {
-                    const result = await originalAll<T>();
-                    if (isWriteOperation) {
-                        await this.mirrorToPostgres(sql, params);
-                    }
-                    return result;
-                };
-
-                bound.first = async <T = Record<string, unknown>>(colName?: string): Promise<T | null> => {
-                    const result = await (colName ? originalFirst<T>(colName) : originalFirst<T>());
-                    if (isWriteOperation) {
-                        await this.mirrorToPostgres(sql, params);
-                    }
-                    return result;
-                };
-
-                return bound;
+            patchedStatement.bind = (...args: unknown[]) => {
+                const normalizedParams = normalizeParams(args);
+                const boundStatement = originalBind(...args as []);
+                return this.patchStatement(boundStatement, sql, normalizedParams);
             };
 
-            return stmt;
+            return patchedStatement;
         };
     }
 
+    private patchStatement(statement: D1PreparedStatement, sql: string, params: unknown[]) {
+        const boundParams = [...params];
+        const isWriteOperation = this.isWriteSQL(sql);
+
+        const originalRun = statement.run.bind(statement);
+        const originalAll = statement.all.bind(statement);
+        const originalFirst = statement.first.bind(statement);
+
+        statement.run = async <T = Record<string, unknown>>(): Promise<D1Result<T>> => {
+            const result = await originalRun<T>();
+            if (isWriteOperation) {
+                await this.mirrorToPostgres(sql, boundParams);
+            }
+            return result;
+        };
+
+        statement.all = async <T = Record<string, unknown>>(): Promise<D1Result<T>> => {
+            const result = await originalAll<T>();
+            if (isWriteOperation) {
+                await this.mirrorToPostgres(sql, boundParams);
+            }
+            return result;
+        };
+
+        statement.first = async <T = Record<string, unknown>>(colName?: string): Promise<T | null> => {
+            const result = await (colName ? originalFirst<T>(colName) : originalFirst<T>());
+            if (isWriteOperation) {
+                await this.mirrorToPostgres(sql, boundParams);
+            }
+            return result;
+        };
+
+        return statement;
+    }
+
     private isWriteSQL(sql: string): boolean {
-        // Remove comments and normalize whitespace
         const cleanSql = sql
-            .replace(/--.*$/gm, '') // Remove line comments
-            .replace(/\/\*[\s\S]*?\*\//g, '') // Remove block comments
-            .replace(/\s+/g, ' ') // Normalize whitespace
+            .replace(/--.*$/gm, '')
+            .replace(/\/\*[\s\S]*?\*\//g, '')
+            .replace(/\s+/g, ' ')
             .trim()
             .toLowerCase();
 
         if (!cleanSql) return false;
 
-        // Split by semicolons to handle multi-statement SQL
-        const statements = cleanSql.split(';').map(s => s.trim()).filter(s => s.length > 0);
+        const statements = cleanSql
+            .split(';')
+            .map(s => s.trim())
+            .filter(s => s.length > 0);
 
-        // Check if any statement is a write operation
         return statements.some(statement => {
             const firstWord = statement.split(/\s+/)[0];
             return ['insert', 'update', 'delete', 'replace', 'create', 'drop', 'alter'].includes(firstWord);
@@ -75,22 +80,16 @@ export class AutoMirrorDB {
 
     private async mirrorToPostgres(sql: string, params: unknown[]) {
         try {
-            const pgSql = this.convertPlaceholders(sql, params.length);
+            const pgSql = convertSqlitePlaceholdersToPostgres(sql);
             const opId = crypto.randomUUID();
 
             await this.env.MIRROR_QUEUE.send({
                 sql: pgSql,
-                params,
+                params: [...params],
                 opId
             });
         } catch (error) {
             console.error('Failed to queue mirror operation:', error);
-            // Don't throw - we don't want mirroring failures to break the main operation
         }
     }
-
-    private convertPlaceholders(sql: string, count: number): string {
-        let i = 1;
-        return sql.replace(/\?/g, () => `$${i++}`);
-    }
-} 
+}

--- a/src/db-router.ts
+++ b/src/db-router.ts
@@ -1,4 +1,5 @@
 import { Env } from './worker';
+import { TableColumn, convertSqlitePlaceholdersToPostgres, quoteIdentifier } from './sql-utils';
 
 export async function executeQuery(env: Env, sql: string, params: unknown[] = []) {
     if (env.PRIMARY_DB === "pg") {
@@ -16,7 +17,7 @@ export async function executeQuery(env: Env, sql: string, params: unknown[] = []
             await client.connect();
 
             // Convert D1 placeholders to Postgres placeholders
-            const pgSql = convertPlaceholders(sql, params.length);
+            const pgSql = convertSqlitePlaceholdersToPostgres(sql);
             const result = await client.query(pgSql, params);
 
             // Return in D1-compatible format
@@ -71,8 +72,8 @@ export async function executeQuery(env: Env, sql: string, params: unknown[] = []
     }
 }
 
-export async function getTableInfo(env: Env, tableName: string) {
-    const sql = `PRAGMA table_info(${tableName})`;
+export async function getTableInfo(env: Env, tableName: string): Promise<TableColumn[]> {
+    const sql = `PRAGMA table_info(${quoteIdentifier(tableName)})`;
 
     if (env.PRIMARY_DB === "pg") {
         // Get table info from Postgres
@@ -107,7 +108,7 @@ export async function getTableInfo(env: Env, tableName: string) {
                 ORDER BY ordinal_position
             `, [tableName]);
 
-            return result.rows;
+            return result.rows as TableColumn[];
         } catch (error) {
             console.error('Failed to get table info from Postgres:', error);
             throw new Error('Failed to get table schema');
@@ -123,7 +124,7 @@ export async function getTableInfo(env: Env, tableName: string) {
         try {
             const stmt = env.DB.prepare(sql);
             const result = await stmt.all();
-            return result.results;
+            return result.results as unknown as TableColumn[];
         } catch (error) {
             console.error('Failed to get table info from D1:', error);
             throw new Error('Failed to get table schema');
@@ -169,7 +170,7 @@ export async function getAllTables(env: Env): Promise<string[]> {
         // Get tables from D1
         try {
             const stmt = env.DB.prepare(`
-                SELECT name FROM sqlite_master 
+                SELECT name FROM sqlite_master
                 WHERE type='table' AND name NOT LIKE 'sqlite_%'
                 ORDER BY name
             `);
@@ -181,8 +182,3 @@ export async function getAllTables(env: Env): Promise<string[]> {
         }
     }
 }
-
-function convertPlaceholders(sql: string, count: number): string {
-    let i = 1;
-    return sql.replace(/\?/g, () => `$${i++}`);
-} 

--- a/src/export-helper.ts
+++ b/src/export-helper.ts
@@ -1,17 +1,31 @@
 import { Env } from './worker';
+import { TableColumn, deriveOrderingColumns, formatPostgresValue, quoteIdentifier } from './sql-utils';
 
 interface ExportOptions {
     batchSize?: number;
     tableName: string;
-    orderBy?: string;
+    orderBy?: string | string[];
     whereClause?: string;
+    schema?: TableColumn[];
 }
 
 /**
  * Stream export D1 data in batches to avoid memory issues
  */
 export async function* streamTableData(env: Env, options: ExportOptions) {
-    const { tableName, batchSize = 1000, orderBy = 'id', whereClause } = options;
+    const { tableName, batchSize = 1000, orderBy, whereClause, schema } = options;
+
+    const orderingColumns = Array.isArray(orderBy)
+        ? orderBy
+        : orderBy
+            ? [orderBy]
+            : deriveOrderingColumns(schema);
+
+    const tableIdentifier = quoteIdentifier(tableName);
+    const resolvedOrdering = orderingColumns.length > 0 ? orderingColumns : ['rowid'];
+    const orderByClause = resolvedOrdering
+        .map(column => column.toLowerCase() === 'rowid' ? 'rowid' : quoteIdentifier(column))
+        .join(', ');
 
     let offset = 0;
     let hasMore = true;
@@ -19,10 +33,10 @@ export async function* streamTableData(env: Env, options: ExportOptions) {
     while (hasMore) {
         const whereSQL = whereClause ? `WHERE ${whereClause}` : '';
         const sql = `
-      SELECT * FROM ${tableName} 
+      SELECT * FROM ${tableIdentifier}
       ${whereSQL}
-      ORDER BY ${orderBy} 
-      LIMIT ${batchSize} 
+      ORDER BY ${orderByClause}
+      LIMIT ${batchSize}
       OFFSET ${offset}
     `;
 
@@ -50,10 +64,10 @@ export async function* streamTableData(env: Env, options: ExportOptions) {
 /**
  * Get table schema information from D1
  */
-export async function getTableSchema(env: Env, tableName: string) {
-    const stmt = env.DB.prepare(`PRAGMA table_info(${tableName})`);
+export async function getTableSchema(env: Env, tableName: string): Promise<TableColumn[]> {
+    const stmt = env.DB.prepare(`PRAGMA table_info(${quoteIdentifier(tableName)})`);
     const result = await stmt.all();
-    return result.results;
+    return result.results as unknown as TableColumn[];
 }
 
 /**
@@ -75,22 +89,17 @@ export async function getAllTables(env: Env): Promise<string[]> {
 export function generatePostgresInserts(
     tableName: string,
     rows: any[],
-    schema: any[]
+    schema: TableColumn[]
 ): string[] {
     if (rows.length === 0) return [];
 
     const columns = schema.map(col => col.name);
-    const columnList = columns.join(', ');
+    const quotedTableName = quoteIdentifier(tableName);
+    const columnList = columns.map(quoteIdentifier).join(', ');
 
     return rows.map(row => {
-        const values = columns.map(col => {
-            const value = row[col];
-            if (value === null) return 'NULL';
-            if (typeof value === 'string') return `'${value.replace(/'/g, "''")}'`;
-            if (typeof value === 'boolean') return value ? 'TRUE' : 'FALSE';
-            return value;
-        }).join(', ');
+        const values = columns.map(col => formatPostgresValue(row[col] ?? null)).join(', ');
 
-        return `INSERT INTO ${tableName} (${columnList}) VALUES (${values}) ON CONFLICT DO NOTHING;`;
+        return `INSERT INTO ${quotedTableName} (${columnList}) VALUES (${values}) ON CONFLICT DO NOTHING;`;
     });
-} 
+}

--- a/src/export-worker.ts
+++ b/src/export-worker.ts
@@ -47,7 +47,7 @@ async function streamSqlExport(env: Env, tableName: string, batchSize: number, s
             controller.enqueue(encoder.encode(header));
 
             try {
-                for await (const batch of streamTableData(env, { tableName, batchSize })) {
+                for await (const batch of streamTableData(env, { tableName, batchSize, schema })) {
                     const inserts = generatePostgresInserts(tableName, batch.rows, schema);
                     const sql = inserts.join('\n') + '\n\n';
                     controller.enqueue(encoder.encode(sql));
@@ -87,7 +87,7 @@ async function streamJsonExport(env: Env, tableName: string, batchSize: number, 
             controller.enqueue(encoder.encode(',\n  "data": [\n'));
 
             try {
-                for await (const batch of streamTableData(env, { tableName, batchSize })) {
+                for await (const batch of streamTableData(env, { tableName, batchSize, schema })) {
                     for (const row of batch.rows) {
                         if (!isFirst) {
                             controller.enqueue(encoder.encode(',\n'));

--- a/src/schema-helper.ts
+++ b/src/schema-helper.ts
@@ -1,3 +1,5 @@
+import { TableColumn, quoteIdentifier } from './sql-utils';
+
 /**
  * Schema conversion utilities for D1 to Postgres migration
  */
@@ -49,7 +51,7 @@ ${postgresSchema}
     };
 }
 
-export function convertD1SchemaToPostgres(schema: Record<string, any[]>): string {
+export function convertD1SchemaToPostgres(schema: Record<string, TableColumn[]>): string {
     const tables = Object.keys(schema);
     const migrationScript: string[] = [];
 
@@ -69,16 +71,16 @@ export function convertD1SchemaToPostgres(schema: Record<string, any[]>): string
     for (const tableName of tables) {
         const columns = schema[tableName];
         migrationScript.push(`-- Table: ${tableName}`);
-        migrationScript.push(`CREATE TABLE IF NOT EXISTS ${tableName} (`);
+        migrationScript.push(`CREATE TABLE IF NOT EXISTS ${quoteIdentifier(tableName)} (`);
 
         const columnDefinitions: string[] = [];
-        const primaryKeys: string[] = [];
+        const primaryKeys: { name: string; order: number }[] = [];
 
         for (const column of columns) {
             const { name, type, notnull, dflt_value, pk } = column;
 
-            let pgType = convertSqliteTypeToPostgres(type);
-            let columnDef = `  ${name} ${pgType}`;
+            let pgType = convertSqliteTypeToPostgres(type ?? 'TEXT');
+            let columnDef = `  ${quoteIdentifier(name)} ${pgType}`;
 
             // Handle NOT NULL
             if (notnull) {
@@ -87,15 +89,25 @@ export function convertD1SchemaToPostgres(schema: Record<string, any[]>): string
 
             // Handle default values
             if (dflt_value !== null && dflt_value !== undefined) {
-                let defaultValue = dflt_value;
+                let defaultValue: string;
 
-                // Convert SQLite-specific defaults
-                if (defaultValue === 'CURRENT_TIMESTAMP') {
-                    defaultValue = 'CURRENT_TIMESTAMP';
-                } else if (defaultValue.includes('unixepoch()')) {
-                    defaultValue = 'extract(epoch from now())';
-                } else if (typeof defaultValue === 'string' && !defaultValue.includes('(')) {
-                    defaultValue = `'${defaultValue}'`;
+                if (typeof dflt_value === 'string') {
+                    const trimmed = dflt_value.trim();
+                    if (trimmed.toUpperCase() === 'CURRENT_TIMESTAMP') {
+                        defaultValue = 'CURRENT_TIMESTAMP';
+                    } else if (/unixepoch\(\)/i.test(trimmed)) {
+                        defaultValue = 'extract(epoch from now())';
+                    } else if (!trimmed.includes('(')) {
+                        defaultValue = `'${escapeSingleQuotes(trimmed)}'`;
+                    } else {
+                        defaultValue = trimmed;
+                    }
+                } else if (typeof dflt_value === 'number' || typeof dflt_value === 'bigint') {
+                    defaultValue = dflt_value.toString();
+                } else if (typeof dflt_value === 'boolean') {
+                    defaultValue = dflt_value ? 'TRUE' : 'FALSE';
+                } else {
+                    defaultValue = `'${escapeSingleQuotes(JSON.stringify(dflt_value))}'::jsonb`;
                 }
 
                 columnDef += ` DEFAULT ${defaultValue}`;
@@ -105,13 +117,16 @@ export function convertD1SchemaToPostgres(schema: Record<string, any[]>): string
 
             // Track primary keys
             if (pk) {
-                primaryKeys.push(name);
+                primaryKeys.push({ name, order: pk });
             }
         }
 
         // Add primary key constraint if exists
         if (primaryKeys.length > 0) {
-            columnDefinitions.push(`  PRIMARY KEY (${primaryKeys.join(', ')})`);
+            const sortedKeys = primaryKeys
+                .sort((a, b) => a.order - b.order)
+                .map(key => quoteIdentifier(key.name));
+            columnDefinitions.push(`  PRIMARY KEY (${sortedKeys.join(', ')})`);
         }
 
         migrationScript.push(columnDefinitions.join(',\n'));
@@ -126,7 +141,7 @@ export function convertD1SchemaToPostgres(schema: Record<string, any[]>): string
         // Create index on primary key columns (if not already primary key)
         const nonPkColumns = columns.filter(col => !col.pk && (col.name.includes('id') || col.name.includes('_id')));
         for (const column of nonPkColumns) {
-            migrationScript.push(`CREATE INDEX IF NOT EXISTS idx_${tableName}_${column.name} ON ${tableName}(${column.name});`);
+            migrationScript.push(`CREATE INDEX IF NOT EXISTS ${quoteIdentifier(`idx_${tableName}_${column.name}`)} ON ${quoteIdentifier(tableName)}(${quoteIdentifier(column.name)});`);
         }
     }
 
@@ -181,4 +196,8 @@ function convertSqliteTypeToPostgres(sqliteType: string): string {
 
     // Default to TEXT for unknown types
     return 'TEXT';
-} 
+}
+
+function escapeSingleQuotes(value: string): string {
+    return value.replace(/'/g, "''");
+}

--- a/src/sql-utils.ts
+++ b/src/sql-utils.ts
@@ -1,0 +1,120 @@
+export interface TableColumn {
+    name: string;
+    type?: string;
+    notnull?: number | boolean;
+    dflt_value?: unknown;
+    pk?: number;
+}
+
+export function quoteIdentifier(name: string): string {
+    return `"${String(name).replace(/"/g, '""')}"`;
+}
+
+export function deriveOrderingColumns(schema?: TableColumn[]): string[] {
+    if (schema && schema.length > 0) {
+        const primaryKeys = schema
+            .filter(column => typeof column.pk === 'number' && column.pk > 0)
+            .sort((a, b) => (a.pk ?? 0) - (b.pk ?? 0))
+            .map(column => column.name)
+            .filter(Boolean);
+
+        if (primaryKeys.length > 0) {
+            return primaryKeys;
+        }
+
+        return [schema[0].name];
+    }
+
+    return ['rowid'];
+}
+
+export function normalizeParams(args: unknown[]): unknown[] {
+    if (args.length === 0) {
+        return [];
+    }
+
+    if (args.length === 1 && Array.isArray(args[0])) {
+        return [...args[0]];
+    }
+
+    return [...args];
+}
+
+export function convertSqlitePlaceholdersToPostgres(sql: string): string {
+    const explicitIndexes = new Set<number>();
+    let nextIndex = 1;
+
+    const getNextIndex = () => {
+        while (explicitIndexes.has(nextIndex)) {
+            nextIndex += 1;
+        }
+        const value = nextIndex;
+        nextIndex += 1;
+        return value;
+    };
+
+    return sql.replace(/\?(\d+)?/g, (_match, explicit) => {
+        if (explicit) {
+            const index = Number(explicit);
+            explicitIndexes.add(index);
+            return `$${index}`;
+        }
+        const index = getNextIndex();
+        return `$${index}`;
+    });
+}
+
+export function formatPostgresValue(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'NULL';
+    }
+
+    if (typeof value === 'number') {
+        if (!Number.isFinite(value)) {
+            return 'NULL';
+        }
+        return value.toString();
+    }
+
+    if (typeof value === 'bigint') {
+        return value.toString();
+    }
+
+    if (typeof value === 'boolean') {
+        return value ? 'TRUE' : 'FALSE';
+    }
+
+    if (value instanceof Date) {
+        return `'${value.toISOString()}'`;
+    }
+
+    if (value instanceof ArrayBuffer) {
+        return `'\\x${toHex(new Uint8Array(value))}'::bytea`;
+    }
+
+    if (value instanceof Uint8Array) {
+        return `'\\x${toHex(value)}'::bytea`;
+    }
+
+    if (Array.isArray(value)) {
+        return `'${escapeSingleQuotes(JSON.stringify(value))}'::jsonb`;
+    }
+
+    if (typeof value === 'object') {
+        return `'${escapeSingleQuotes(JSON.stringify(value))}'::jsonb`;
+    }
+
+    return `'${escapeSingleQuotes(String(value))}'`;
+}
+
+function toHex(bytes: Uint8Array): string {
+    let result = '';
+    for (const byte of bytes) {
+        result += byte.toString(16).padStart(2, '0');
+    }
+    return result;
+}
+
+function escapeSingleQuotes(value: string): string {
+    return value.replace(/'/g, "''");
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,6 +1,7 @@
 import { executeQuery, getTableInfo, getAllTables } from './db-router';
 import { AutoMirrorDB } from './auto-mirror';
 import { handleExport } from './export-worker';
+import type { TableColumn } from './sql-utils';
 
 export interface Env {
     DB: D1Database;
@@ -53,7 +54,7 @@ export default {
             if (req.method === "GET" && url.pathname === "/schema") {
                 try {
                     const tables = await getAllTables(env);
-                    const schema: Record<string, any[]> = {};
+                    const schema: Record<string, TableColumn[]> = {};
 
                     for (const table of tables) {
                         schema[table] = await getTableInfo(env, table);
@@ -86,7 +87,7 @@ export default {
             if (req.method === "GET" && url.pathname === "/migration-script") {
                 try {
                     const tables = await getAllTables(env);
-                    const schema: Record<string, any[]> = {};
+                    const schema: Record<string, TableColumn[]> = {};
 
                     for (const table of tables) {
                         schema[table] = await getTableInfo(env, table);
@@ -161,7 +162,7 @@ export default {
     }
 };
 
-async function generatePostgresMigrationScript(schema: Record<string, any[]>): Promise<string> {
+async function generatePostgresMigrationScript(schema: Record<string, TableColumn[]>): Promise<string> {
     const { convertD1SchemaToPostgres } = await import('./schema-helper');
     return convertD1SchemaToPostgres(schema);
-} 
+}


### PR DESCRIPTION
## Summary
- add shared SQL utilities for identifier quoting, placeholder conversion, and Postgres value formatting to support arbitrary schemas
- patch prepared statement execution so every D1 write is mirrored with normalized parameters and placeholder conversion
- stream exports and generate migrations using discovered primary keys and quoted identifiers for any table shape

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68cc85a26ea483249bedb4ba2eb0250f